### PR TITLE
Restrict package to win32

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,5 +12,8 @@
     "Window",
     "Console",
     "Console Window"
+  ],
+  "os": [
+    "win32"
   ]
 }


### PR DESCRIPTION
Hello! I'm third who add this lines to fork :)

I have cross-os app (windows/linux), added to [package.json](https://github.com/popstas/windows-mqtt/blob/master/package.json#L25) `optionalDependencies`, it work, but too many errors displayed when no os restrict.